### PR TITLE
feat: Swift6 annotations of thread safe existing code

### DIFF
--- a/Sources/InfomaniakDI/Factory.swift
+++ b/Sources/InfomaniakDI/Factory.swift
@@ -17,7 +17,7 @@ import Foundation
 public typealias FactoryClosure = (_ parameters: [String: Any]?, _ resolver: SimpleResolvable) throws -> Any
 
 /// Something that can build a type
-public protocol Factoryable {
+public protocol Factoryable: Sendable {
     /// Required init for a Factoryable
     /// - Parameters:
     ///   - type: The type we register, prefer using a Protocol here. Great for testing.
@@ -35,7 +35,7 @@ public protocol Factoryable {
     var type: Any.Type { get }
 }
 
-public struct Factory: Factoryable, CustomDebugStringConvertible {
+public struct Factory: Factoryable, CustomDebugStringConvertible, @unchecked Sendable {
     /// The factory closure
     private let closure: FactoryClosure
 

--- a/Sources/InfomaniakDI/SimpleResolver.swift
+++ b/Sources/InfomaniakDI/SimpleResolver.swift
@@ -18,7 +18,7 @@ import Foundation
 /// Something minimalist that can resolve a concrete type
 ///
 /// Servicies are kept alive for the duration of the app's life
-public protocol SimpleResolvable {
+public protocol SimpleResolvable: Sendable {
     /// The main solver funtion, tries to fetch an existing object or apply a factory if availlable
     /// - Parameters:
     ///   - type: the wanted type
@@ -34,7 +34,7 @@ public protocol SimpleResolvable {
 }
 
 /// Something that stores a factory for a given type
-public protocol SimpleStorable {
+public protocol SimpleStorable: Sendable {
     /// Store a factory closure for a given type
     ///
     /// You will virtualy never call this directly
@@ -48,7 +48,7 @@ public protocol SimpleStorable {
 
 /// A minimalist DI solution
 /// Once initiated, stores types as long as the app lives
-public final class SimpleResolver: SimpleResolvable, SimpleStorable, CustomDebugStringConvertible {
+public final class SimpleResolver: SimpleResolvable, SimpleStorable, CustomDebugStringConvertible, @unchecked Sendable {
     public var debugDescription: String {
         var buffer: String!
         queue.sync {


### PR DESCRIPTION
__InfomaniakDI__ _is_ thread safe.
Yet this GCD based code needs to explicit some things to the `Swift6` compiler to work seamlessly when built in Swift6 mode.

This is not a pure `Swift structured concurrency rewrite`, and this might not actually be the best thing to do with this library.

This is a simple quick win and should be transparently released as a 1.0.1