### PR TITLE
fix: Property wrappers are now thread safe

### DIFF
--- a/Sources/InfomaniakDI/InjectService.swift
+++ b/Sources/InfomaniakDI/InjectService.swift
@@ -16,7 +16,7 @@ import Foundation
 // MARK: - InjectService<Service>
 
 /// A property wrapper that resolves shared objects when the host type is initialized.
-@propertyWrapper public struct InjectService<Service>: CustomDebugStringConvertible, Equatable, Identifiable {
+@propertyWrapper public struct InjectService<Service: Sendable>: CustomDebugStringConvertible, Equatable, Identifiable, Sendable {
     /// Identifiable
     ///
     /// Something to link the identity of this property wrapper to the underlying Service type.
@@ -40,15 +40,14 @@ import Foundation
         """
     }
 
-    /// Store the resolved service
-    var service: Service!
+    let service: Service
 
-    public var container: SimpleResolvable
-    public var customTypeIdentifier: String?
-    public var factoryParameters: [String: Any]?
+    public let container: SimpleResolvable
+    public let customTypeIdentifier: String?
+    public let factoryParameters: [String: Sendable]?
 
     public init(customTypeIdentifier: String? = nil,
-                factoryParameters: [String: Any]? = nil,
+                factoryParameters: [String: Sendable]? = nil,
                 container: SimpleResolvable = SimpleResolver.sharedResolver) {
         self.customTypeIdentifier = customTypeIdentifier
         self.factoryParameters = factoryParameters

--- a/Sources/InfomaniakDI/InjectService.swift
+++ b/Sources/InfomaniakDI/InjectService.swift
@@ -16,7 +16,8 @@ import Foundation
 // MARK: - InjectService<Service>
 
 /// A property wrapper that resolves shared objects when the host type is initialized.
-@propertyWrapper public struct InjectService<Service: Sendable>: CustomDebugStringConvertible, Equatable, Identifiable, Sendable {
+@propertyWrapper public struct InjectService<Service>: CustomDebugStringConvertible, Equatable, Identifiable,
+    @unchecked Sendable {
     /// Identifiable
     ///
     /// Something to link the identity of this property wrapper to the underlying Service type.
@@ -44,10 +45,10 @@ import Foundation
 
     public let container: SimpleResolvable
     public let customTypeIdentifier: String?
-    public let factoryParameters: [String: Sendable]?
+    public let factoryParameters: [String: Any]?
 
     public init(customTypeIdentifier: String? = nil,
-                factoryParameters: [String: Sendable]? = nil,
+                factoryParameters: [String: Any]? = nil,
                 container: SimpleResolvable = SimpleResolver.sharedResolver) {
         self.customTypeIdentifier = customTypeIdentifier
         self.factoryParameters = factoryParameters

--- a/Sources/InfomaniakDI/LazyInjectService.swift
+++ b/Sources/InfomaniakDI/LazyInjectService.swift
@@ -14,7 +14,7 @@
 import Foundation
 
 /// Inject a service at the first use of the property
-@propertyWrapper public final class LazyInjectService<Service: Sendable>: Equatable, Identifiable, @unchecked Sendable {
+@propertyWrapper public final class LazyInjectService<Service>: Equatable, Identifiable, @unchecked Sendable {
     private let semaphore = DispatchSemaphore(value: 1)
 
     var service: Service?
@@ -44,10 +44,10 @@ import Foundation
 
     public let container: SimpleResolvable
     public let customTypeIdentifier: String?
-    public let factoryParameters: [String: Sendable]?
+    public let factoryParameters: [String: Any]?
 
     public init(customTypeIdentifier: String? = nil,
-                factoryParameters: [String: Sendable]? = nil,
+                factoryParameters: [String: Any]? = nil,
                 container: SimpleResolvable = SimpleResolver.sharedResolver) {
         self.customTypeIdentifier = customTypeIdentifier
         self.factoryParameters = factoryParameters


### PR DESCRIPTION
An interesting __rare__ bug pointed me to the fact that DI resolution _was_ thread safe but property wrappers were not.
This is fixing that. Now a class can expose a @LazyInjectService (or @InjectService), access it from any random thread _concurrently_ and it won't cause a crash.

`InjectService` is made `@unchecked Sendable`.
`LazyInjectService` is now `@unchecked Sendable` with a GCD `DispatchSemaphore` as I need to express the `Lazy` part of it.

Reworked the PR to maintain a swift 5.8<->6.0 compatibility while maintaining thread safety.

This PR is now __backward__ _and_ __forward__ compatible. Can be published as a 2.0.3