### PR TITLE
refactor: Switch to recursive lock

### DIFF
--- a/Sources/InfomaniakDI/SimpleResolver.swift
+++ b/Sources/InfomaniakDI/SimpleResolver.swift
@@ -66,7 +66,6 @@ public final class SimpleResolver: SimpleResolvable, SimpleStorable, CustomDebug
     enum ErrorDomain: Error {
         case factoryMissing(identifier: String)
         case typeMissmatch(expected: String, got: String)
-        case unknown
     }
 
     /// One singleton to rule them all


### PR DESCRIPTION
Switching `SimpleResolver` to a recursive lock. 
This fixes a rare bug in `loadOrResolve()`, reduce latency, and is now cleaner than an internal queue.

In my synthetic tests, this is 19% faster than 2.0.3

More details in the [exploratory PR](https://github.com/Infomaniak/swift-dependency-injection/pull/11)