### PR TITLE
fix(InjectService): Remove extraneous computed property

### DIFF
--- a/Sources/InfomaniakDI/InjectService.swift
+++ b/Sources/InfomaniakDI/InjectService.swift
@@ -41,8 +41,7 @@ import Foundation
         """
     }
 
-    let service: Service
-
+    public let wrappedValue: Service
     public let container: SimpleResolvable
     public let customTypeIdentifier: String?
     public let factoryParameters: [String: Any]?
@@ -55,21 +54,12 @@ import Foundation
         self.container = container
 
         do {
-            service = try container.resolve(type: Service.self,
-                                            forCustomTypeIdentifier: customTypeIdentifier,
-                                            factoryParameters: factoryParameters,
-                                            resolver: container)
+            wrappedValue = try container.resolve(type: Service.self,
+                                                 forCustomTypeIdentifier: customTypeIdentifier,
+                                                 factoryParameters: factoryParameters,
+                                                 resolver: container)
         } catch {
             fatalError("DI fatal error :\(error)")
-        }
-    }
-
-    public var wrappedValue: Service {
-        get {
-            service
-        }
-        set {
-            fatalError("You are not expected to substitute resolved objects")
         }
     }
 

--- a/Tests/InfomaniakDITests/ITInjectService.swift
+++ b/Tests/InfomaniakDITests/ITInjectService.swift
@@ -40,7 +40,7 @@ final class ITInjectService: XCTestCase {
 
         // WHEN
         let classWithDIProperty = ClassThatUsesDI()
-        XCTAssertNotNil(classWithDIProperty.$injected.service, "the service is expected to be resolved")
+        XCTAssertNotNil(classWithDIProperty.$injected.wrappedValue, "the service is expected to be resolved")
 
         // THEN
         XCTAssertTrue(expectedObject === classWithDIProperty.injected, "identity of resolved object should match")
@@ -65,7 +65,7 @@ final class ITInjectService: XCTestCase {
 
         // WHEN
         let classWithDIProperty = ClassThatUsesConformingDI()
-        XCTAssertNotNil(classWithDIProperty.$injected.service, "the service is expected to be resolved")
+        XCTAssertNotNil(classWithDIProperty.$injected.wrappedValue, "the service is expected to be resolved")
 
         // THEN
         XCTAssertTrue(expectedObject === classWithDIProperty.injected, "identity of resolved object should match")
@@ -94,8 +94,8 @@ final class ITInjectService: XCTestCase {
 
         // WHEN
         let classWithServicies = ClassThatUsesCustomIdentifiersDI()
-        XCTAssertNotNil(classWithServicies.$special.service, "the service is expected to be resolved")
-        XCTAssertNotNil(classWithServicies.$custom.service, "the service is expected to be resolved")
+        XCTAssertNotNil(classWithServicies.$special.wrappedValue, "the service is expected to be resolved")
+        XCTAssertNotNil(classWithServicies.$custom.wrappedValue, "the service is expected to be resolved")
 
         // THEN
         XCTAssertFalse(classWithServicies.custom === classWithServicies.special,
@@ -127,7 +127,7 @@ final class ITInjectService: XCTestCase {
 
         // WHEN
         let classWithService = ClassThatUsesFactoryParametersDI()
-        XCTAssertNotNil(classWithService.$injected.service, "the service is expected to be resolved")
+        XCTAssertNotNil(classWithService.$injected.wrappedValue, "the service is expected to be resolved")
 
         // THEN
         XCTAssertTrue(classWithService.injected === expectedObject, "the identity is expected to match")
@@ -162,8 +162,8 @@ final class ITInjectService: XCTestCase {
 
         // WHEN
         let classWithServicies = ClassThatUsesComplexDI()
-        XCTAssertNotNil(classWithServicies.$special.service, "the service is expected to be resolved")
-        XCTAssertNotNil(classWithServicies.$custom.service, "the service is expected to be resolved")
+        XCTAssertNotNil(classWithServicies.$special.wrappedValue, "the service is expected to be resolved")
+        XCTAssertNotNil(classWithServicies.$custom.wrappedValue, "the service is expected to be resolved")
 
         // THEN
         XCTAssertFalse(classWithServicies.custom === classWithServicies.special,


### PR DESCRIPTION
Remove extraneous computed property that can generate Swift6 concurrency warnings.
This is intended to be 100% compatible with existing code.