### PR TITLE
fix: Threadsafe recursive lock on `resolve`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,4 @@
-// swift-tools-version: 5.6
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
+// swift-tools-version: 5.9
 import PackageDescription
 
 let package = Package(

--- a/Sources/InfomaniakDI/SafeRecursiveLock.swift
+++ b/Sources/InfomaniakDI/SafeRecursiveLock.swift
@@ -1,0 +1,67 @@
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+import Foundation
+
+/// A Thread safe recursive lock
+///
+/// Unlike `NSRecursiveLock`, it can be called from arbitrary threads without creating deadlocks.
+final class SafeRecursiveLock: @unchecked Sendable {
+    private let accessSemaphore = DispatchSemaphore(value: 1)
+    private let internalLock = NSLock()
+
+    private var owningThread: Thread?
+    private var recursionCount: Int = 0
+
+    @inline(__always)
+    func lock() {
+        let currentThread = Thread.current
+
+        internalLock.lock()
+        if owningThread == currentThread {
+            // Recursive lock by the same thread
+            recursionCount += 1
+            internalLock.unlock()
+            return
+        }
+        internalLock.unlock()
+
+        // Wait until lock is available
+        accessSemaphore.wait()
+
+        // We now own the lock
+        internalLock.lock()
+        owningThread = currentThread
+        recursionCount = 1
+        internalLock.unlock()
+    }
+
+    @inline(__always)
+    func unlock() {
+        internalLock.lock()
+        let currentThread = Thread.current
+        guard owningThread == currentThread else {
+            internalLock.unlock()
+            fatalError("Unlock called from a different thread!")
+        }
+
+        recursionCount -= 1
+        if recursionCount == 0 {
+            owningThread = nil
+            internalLock.unlock()
+            accessSemaphore.signal() // allow other threads to acquire
+        } else {
+            internalLock.unlock()
+        }
+    }
+}

--- a/Sources/InfomaniakDI/SafeRecursiveLock.swift
+++ b/Sources/InfomaniakDI/SafeRecursiveLock.swift
@@ -12,53 +12,42 @@
 //  under the License.
 
 import Foundation
+import os.lock
 
 /// A thread safe recursive lock
 ///
 /// Unlike `NSRecursiveLock`, it can be called from arbitrary threads without creating deadlocks.
 final class SafeRecursiveLock: @unchecked Sendable {
-    private let accessSemaphore = DispatchSemaphore(value: 1)
-    private let internalLock = NSLock()
-
+    private var unfairLock = os_unfair_lock()
     private var owningThread: Thread?
     private var recursionCount: Int = 0
 
     @inline(__always)
     func lock() {
-        let currentThread = Thread.current
+        let currentTread = Thread.current
 
-        internalLock.lock()
-        if owningThread == currentThread {
+        if owningThread === currentTread {
             recursionCount += 1
-            internalLock.unlock()
             return
         }
-        internalLock.unlock()
 
-        accessSemaphore.wait()
-
-        internalLock.lock()
-        owningThread = currentThread
+        os_unfair_lock_lock(&unfairLock)
+        owningThread = currentTread
         recursionCount = 1
-        internalLock.unlock()
     }
 
     @inline(__always)
     func unlock() {
-        internalLock.lock()
-        let currentThread = Thread.current
-        guard owningThread == currentThread else {
-            internalLock.unlock()
-            fatalError("Unlock called from a different thread!")
+        let current = Thread.current
+        guard owningThread === current else {
+            fatalError("Unlock from wrong thread")
         }
 
         recursionCount -= 1
+
         if recursionCount == 0 {
             owningThread = nil
-            internalLock.unlock()
-            accessSemaphore.signal()
-        } else {
-            internalLock.unlock()
+            os_unfair_lock_unlock(&unfairLock)
         }
     }
 }

--- a/Sources/InfomaniakDI/SafeRecursiveLock.swift
+++ b/Sources/InfomaniakDI/SafeRecursiveLock.swift
@@ -13,7 +13,7 @@
 
 import Foundation
 
-/// A Thread safe recursive lock
+/// A thread safe recursive lock
 ///
 /// Unlike `NSRecursiveLock`, it can be called from arbitrary threads without creating deadlocks.
 final class SafeRecursiveLock: @unchecked Sendable {
@@ -29,17 +29,14 @@ final class SafeRecursiveLock: @unchecked Sendable {
 
         internalLock.lock()
         if owningThread == currentThread {
-            // Recursive lock by the same thread
             recursionCount += 1
             internalLock.unlock()
             return
         }
         internalLock.unlock()
 
-        // Wait until lock is available
         accessSemaphore.wait()
 
-        // We now own the lock
         internalLock.lock()
         owningThread = currentThread
         recursionCount = 1
@@ -59,7 +56,7 @@ final class SafeRecursiveLock: @unchecked Sendable {
         if recursionCount == 0 {
             owningThread = nil
             internalLock.unlock()
-            accessSemaphore.signal() // allow other threads to acquire
+            accessSemaphore.signal()
         } else {
             internalLock.unlock()
         }

--- a/Sources/InfomaniakDI/SimpleResolver.swift
+++ b/Sources/InfomaniakDI/SimpleResolver.swift
@@ -49,7 +49,7 @@ public protocol SimpleStorable: Sendable {
 /// A minimalist DI solution
 /// Once initiated, stores types as long as the app lives
 public final class SimpleResolver: SimpleResolvable, SimpleStorable, CustomDebugStringConvertible, @unchecked Sendable {
-    private let recursiveLock = NSRecursiveLock()
+    private let recursiveLock = SafeRecursiveLock()
 
     public var debugDescription: String {
         recursiveLock.lock()

--- a/Tests/InfomaniakDITests/ITSafeRecursiveLock.swift
+++ b/Tests/InfomaniakDITests/ITSafeRecursiveLock.swift
@@ -16,21 +16,29 @@ import Foundation
 import Testing
 
 struct ITSafeRecursiveLock {
-    private let taskCount = 50
-    private let iterationsPerTask = 100
-
-    @Test("Stress test with many concurrent tasks, manual lock/unlock", .timeLimit(.minutes(1)))
-    func manyConcurrentTasksManualLock() {
+    @Test("Stress test with many concurrent tasks, manual lock/unlock from arbitrary queues",
+          arguments: [1, 100, 50], [100, 1, 50])
+    func manyConcurrentTasksManualLock(taskCount: Int, iterationsPerTask: Int) {
         // GIVEN
         let group = DispatchGroup()
         var sharedCounter = 0
         let counterLock = NSLock()
         let safeLock = SafeRecursiveLock()
 
+        // Create a pool of queues to simulate arbitrary queues
+        let queuePool: [DispatchQueue] = (0 ..< 8).map { DispatchQueue(label: "test.queue.\($0)", attributes: .concurrent) }
+
         // WHEN
         for _ in 0 ..< taskCount {
-            DispatchQueue.global().async(group: group) {
+            // Pick a random queue from the pool for this task
+            let randomQueue = queuePool.randomElement()!
+            randomQueue.async(group: group) {
                 for i in 0 ..< iterationsPerTask {
+                    // Small sleep to encourage thread interleaving
+                    if i == 0 || i % 10 == 0 {
+                        Thread.sleep(forTimeInterval: 0.001)
+                    }
+
                     // Explicitly lock/unlock
                     safeLock.lock()
                     counterLock.lock()
@@ -45,32 +53,26 @@ struct ITSafeRecursiveLock {
                     safeLock.unlock()
 
                     safeLock.unlock()
-
-                    // Small sleep to encourage thread interleaving
-                    if i % 10 == 0 {
-                        Thread.sleep(forTimeInterval: 0.001)
-                    }
                 }
             }
         }
 
         // THEN
-        let waitResult = group.wait(timeout: .now() + .seconds(30))
+        let waitResult = group.wait(timeout: .now() + .seconds(240))
         #expect(waitResult == .success)
 
         let expected = taskCount * iterationsPerTask * 2
         #expect(sharedCounter == expected, "sharedCounter should be \(expected), but was \(sharedCounter)")
     }
 
-    @Test("Stress test long hold + many waiters, manual lock/unlock", .timeLimit(.minutes(1)))
-    func longHoldWithManyWaitersManualLock() {
+    @Test("Stress test long hold + many waiters, manual lock/unlock", arguments: [50])
+    func longHoldWithManyWaitersManualLock(taskCount: Int) {
         // GIVEN
         let shortLock = SafeRecursiveLock()
         var sharedSum = 0
         let sumLock = NSLock()
 
         // WHEN
-        // Task 0: long-holding task
         DispatchQueue.global().async {
             shortLock.lock()
             Thread.sleep(forTimeInterval: 1.0)
@@ -94,7 +96,7 @@ struct ITSafeRecursiveLock {
         }
 
         // THEN
-        let waitResult = group.wait(timeout: .now() + .seconds(30))
+        let waitResult = group.wait(timeout: .now() + .seconds(240))
         #expect(waitResult == .success)
 
         #expect(sharedSum == (1 + taskCount), "sharedSum should be \(1 + taskCount), but was \(sharedSum)")

--- a/Tests/InfomaniakDITests/ITSafeRecursiveLock.swift
+++ b/Tests/InfomaniakDITests/ITSafeRecursiveLock.swift
@@ -1,0 +1,102 @@
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+import Foundation
+@testable import InfomaniakDI
+import Testing
+
+struct ITSafeRecursiveLock {
+    private let taskCount = 50
+    private let iterationsPerTask = 100
+
+    @Test("Stress test with many concurrent tasks, manual lock/unlock", .timeLimit(.minutes(1)))
+    func manyConcurrentTasksManualLock() {
+        // GIVEN
+        let group = DispatchGroup()
+        var sharedCounter = 0
+        let counterLock = NSLock()
+        let safeLock = SafeRecursiveLock()
+
+        // WHEN
+        for _ in 0 ..< taskCount {
+            DispatchQueue.global().async(group: group) {
+                for i in 0 ..< iterationsPerTask {
+                    // Explicitly lock/unlock
+                    safeLock.lock()
+                    counterLock.lock()
+                    sharedCounter += 1
+                    counterLock.unlock()
+
+                    // Recursive locking
+                    safeLock.lock()
+                    counterLock.lock()
+                    sharedCounter += 1
+                    counterLock.unlock()
+                    safeLock.unlock()
+
+                    safeLock.unlock()
+
+                    // Small sleep to encourage thread interleaving
+                    if i % 10 == 0 {
+                        Thread.sleep(forTimeInterval: 0.001)
+                    }
+                }
+            }
+        }
+
+        // THEN
+        let waitResult = group.wait(timeout: .now() + .seconds(30))
+        #expect(waitResult == .success)
+
+        let expected = taskCount * iterationsPerTask * 2
+        #expect(sharedCounter == expected, "sharedCounter should be \(expected), but was \(sharedCounter)")
+    }
+
+    @Test("Stress test long hold + many waiters, manual lock/unlock", .timeLimit(.minutes(1)))
+    func longHoldWithManyWaitersManualLock() {
+        // GIVEN
+        let shortLock = SafeRecursiveLock()
+        var sharedSum = 0
+        let sumLock = NSLock()
+
+        // WHEN
+        // Task 0: long-holding task
+        DispatchQueue.global().async {
+            shortLock.lock()
+            Thread.sleep(forTimeInterval: 1.0)
+            sumLock.lock()
+            sharedSum += 1
+            sumLock.unlock()
+            shortLock.unlock()
+        }
+
+        Thread.sleep(forTimeInterval: 0.1)
+
+        let group = DispatchGroup()
+        for _ in 0 ..< taskCount {
+            DispatchQueue.global().async(group: group) {
+                shortLock.lock()
+                sumLock.lock()
+                sharedSum += 1
+                sumLock.unlock()
+                shortLock.unlock()
+            }
+        }
+
+        // THEN
+        let waitResult = group.wait(timeout: .now() + .seconds(30))
+        #expect(waitResult == .success)
+
+        #expect(sharedSum == (1 + taskCount), "sharedSum should be \(1 + taskCount), but was \(sharedSum)")
+    }
+}

--- a/Tests/InfomaniakDITests/UTSafeRecursiveLock.swift
+++ b/Tests/InfomaniakDITests/UTSafeRecursiveLock.swift
@@ -1,0 +1,115 @@
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+import Foundation
+@testable import InfomaniakDI
+import Testing
+
+@MainActor
+struct UTSafeRecursiveLock {
+
+    // MARK: - lock() recursive on same thread
+
+    @Test("lock() allows recursive locking on the same thread", .timeLimit(.minutes(1)))
+    func testLockRecursiveSameThread() {
+        // GIVEN
+        let lock = SafeRecursiveLock()
+        var value = 0
+
+        // WHEN
+        lock.lock()
+        lock.lock() // recursive lock on same thread
+        value += 10
+        lock.unlock()
+        lock.unlock()
+
+        // THEN
+        #expect(value == 10, "Value should be 10 after recursive lock/unlock")
+    }
+
+    // MARK: - lock() blocks other threads
+
+    @Test("lock() blocks other threads until released", .timeLimit(.minutes(1)))
+    func testLockBlocksOtherThreads() {
+        // GIVEN
+        let lock = SafeRecursiveLock()
+        var sharedCounter = 0
+        let group = DispatchGroup()
+        lock.lock() // main thread locks first
+
+        // WHEN
+        DispatchQueue.global().async(group: group) {
+            lock.lock() // should block until main thread unlocks
+            sharedCounter += 1
+            lock.unlock()
+        }
+
+        // give async thread a chance to attempt the lock
+        Thread.sleep(forTimeInterval: 0.1)
+
+        // THEN
+        #expect(sharedCounter == 0, "Shared counter should still be 0, lock not released yet")
+
+        // WHEN
+        lock.unlock() // release lock, allowing other thread to proceed
+
+        // THEN
+        let waitResult = group.wait(timeout: .now() + .seconds(1))
+        #expect(waitResult == .success)
+        #expect(sharedCounter == 1, "Shared counter should be 1 after other thread acquires lock")
+    }
+
+    // MARK: - unlock() releases the lock
+
+    @Test("unlock() releases the lock and allows waiting threads to proceed", .timeLimit(.minutes(1)))
+    func testUnlockReleasesLock() {
+        // GIVEN
+        let lock = SafeRecursiveLock()
+        var sharedCounter = 0
+        let group = DispatchGroup()
+        lock.lock()
+
+        // WHEN
+        DispatchQueue.global().async(group: group) {
+            lock.lock()
+            sharedCounter += 1
+            lock.unlock()
+        }
+
+        // THEN
+        lock.unlock() // release lock for other thread
+        let waitResult = group.wait(timeout: .now() + .seconds(1))
+        #expect(waitResult == .success)
+        #expect(sharedCounter == 1, "Shared counter should be 1 after unlock")
+    }
+
+    // MARK: - unlock() called from wrong thread
+
+    @Test("unlock() from wrong thread triggers fatalError (cannot catch in tests)", .timeLimit(.minutes(1)))
+    func testUnlockFromWrongThread() {
+        // GIVEN
+        let lock = SafeRecursiveLock()
+        lock.lock()
+
+        // WHEN
+        DispatchQueue.global().async {
+            // Normally fatalError cannot be caught in Testing
+            // This shows intent; do not uncomment in real test or it will crash
+            // lock.unlock()
+        }
+
+        // THEN
+        // Just ensure main thread can clean up
+        lock.unlock()
+    }
+}


### PR DESCRIPTION
#### Abstract

A rare issue showed that `SimpleResolver.resolve<Service>()` can deadlock in specific conditions.

`SimpleResolver` uses an internal `NSRecursiveLock`. 
This kind of recursive lock is not _thread safe,_ if `lock()` is called from concurrent threads; testing showed it could deadlock.

#### Proposed solution

A new thread safe recursive lock was created. 
The new `SafeRecursiveLock` is a drop-in replacement for `NSRecursiveLock`.

Some integration tests as well as unit tests were added to validate the behaviour of the new `SafeRecursiveLock` type.