### PR TITLE
feat: Expose dynamic target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,8 @@ let package = Package(
     products: [
         .library(
             name: "InfomaniakDI",
-            targets: ["InfomaniakDI"]),
+            type: .dynamic,
+            targets: ["InfomaniakDI"])
     ],
     dependencies: [
     ],


### PR DESCRIPTION
This allows the standard Xcode SPM library management tool to work properly with this library.
ie. No duplication, one shared "object container" is guaranteed.